### PR TITLE
fix(extension): Adding support for no bucket

### DIFF
--- a/flask_minio/extension.py
+++ b/flask_minio/extension.py
@@ -34,7 +34,7 @@ class Minio(object):
             credentials=app.config.get('MINIO_CREDENTIALS'),
         )
 
-        for bucket in app.config.get('MINIO_BUCKETS'):
+        for bucket in app.config.get('MINIO_BUCKETS', []):
             if not self.client.bucket_exists(bucket):
                 self.client.make_bucket(bucket)
 

--- a/flask_minio/tests/test_extension.py
+++ b/flask_minio/tests/test_extension.py
@@ -26,7 +26,7 @@ def test_minio_client_created_with_init_app():
     assert minio.client.bucket_exists('img') is True
 
 
-def test_mini_client_created_diretly():
+def test_minio_client_created_directly():
     app = Flask(__name__)
 
     # Configuring flask for minio
@@ -40,3 +40,17 @@ def test_mini_client_created_diretly():
 
     assert minio.client is not None
     assert minio.client.bucket_exists('img') is True
+
+
+def test_minio_could_be_created_without_bucket_provided():
+    app = Flask(__name__)
+
+    # Configuring flask for minio
+    app.config['MINIO_URL'] = '172.17.0.1:9000'
+    app.config['MINIO_ACCESS_KEY'] = 'minioaccesskey'
+    app.config['MINIO_SECRET_KEY'] = 'miniosecretkey'
+    app.config['MINIO_SECURE_CONNECTION'] = False
+
+    minio = Minio(app)
+
+    assert minio.client is not None


### PR DESCRIPTION
**Scope**
 - When no bucket is provided for the

**Development**
 - Modified the extension, such that if no `MINIO_BUCKETS` config
variable is provided, then it replaces it with an empty list

**Guide**
 - `pip install .`
 - Try starting the test app without any bucket defined in the config

References: [issue#2](https://github.com/Alias-Innovations/flask_minio/issues/2)